### PR TITLE
Continue launching even if statistics.json is not found (e.g. first use)

### DIFF
--- a/lib/statistics.js
+++ b/lib/statistics.js
@@ -51,8 +51,8 @@ exports.loadStatistics = function(callback) {
 				
 				globalVars.statistics = newStats;
 				saveStatistics();
-				callback();
 			}
+            callback();
 		}
 	);
 }


### PR DESCRIPTION
When trying to launch, I was getting a hang on the "Could not load the statistics.json file (this is fine if you haven't used the bot before)." message.

That appears to have been happening because the callback was only getting called in the success case.  With this change, I was able to successfully launch.  Bot worked properly after that from what I can tell, and statistics,json was created properly.
